### PR TITLE
Chrome updating fix

### DIFF
--- a/background.js
+++ b/background.js
@@ -147,8 +147,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
-// On installation
-chrome.runtime.onInstalled.addListener(() => {
+
+function onInstalled() {
   createContextMenu();
   chrome.storage.local.get('VN_state', function (state) {
     let VN_enabled = true;
@@ -175,6 +175,18 @@ chrome.runtime.onInstalled.addListener(() => {
     }
   });
   chrome.contextMenus.onClicked.addListener(contextMenuListener);
+}
+
+// On installation
+chrome.runtime.onInstalled.addListener(() => {
+  onInstalled();
+});
+// On startup
+// We create the context menu on startup because apparently when Chrome updates
+// it doesn't save context menus
+// Also update state, just in case Chrome update breaks something else
+chrome.runtime.onStartup.addListener(() => {
+  onInstalled();
 });
 chrome.contextMenus.onClicked.addListener(contextMenuListener);
 

--- a/background.js
+++ b/background.js
@@ -181,7 +181,7 @@ function onInstalled() {
 chrome.runtime.onInstalled.addListener(() => {
   onInstalled();
 });
-// On startup
+
 // We create the context menu on startup because apparently when Chrome updates
 // it doesn't save context menus
 // Also update state, just in case Chrome update breaks something else
@@ -249,12 +249,12 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
           }
         });
       }
-      // if(!enabled) toggleContextMenu(false);
-      // else {
-      //   chrome.tabs.query({active: true, currentWindow: true}, tabs => {
-      //     checkContextMenuValid(tabs[0]);
-      //   });
-      // }
+      if(!enabled) toggleContextMenu(false);
+      else {
+        chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+          checkContextMenuValid(tabs[0]);
+        });
+      }
     });    
   }
 });


### PR DESCRIPTION
Please test this fix if you still have an old version of Chrome installed.
1. Remove all existing videoNail extension instances from Chrome.
2. Unpack this extension in Chrome using this branch.
3. Check if contextMenu works. If it does, continue to step 4. 
4. Update Chrome to newest version.
5. Test whether context menu still works. If it does, everything is good.

PS: I re-enabled the contextMenu disable/enable functionality from popupMenu. Check whether it works properly on your end.